### PR TITLE
Feat: implement FetchLimitedTradeAfter query

### DIFF
--- a/pkg/influx/queries.go
+++ b/pkg/influx/queries.go
@@ -60,6 +60,65 @@ func (d *DB) FetchByTimeRange(
 	return data, nil
 }
 
+// FetchLimitedTradeAfter fetches limited trade data for a specific product and time frame after a given start time.
+// It queries the InfluxDB database to retrieve the stock aggregates (open, close, high, low, volume) for the specified product and time frame.
+// The number of results is limited by the 'limit' parameter.
+// The function returns a slice of StockAggregate pointers and an error if any occurred.
+func (d *DB) FetchLimitedTradeAfter(
+	ctx context.Context,
+	productID string,
+	timeFrame string,
+	start time.Time,
+	limit int) ([]*model.StockAggregate, error) {
+
+	reader := d.client.QueryAPI("org")
+	queryRes, err := reader.Query(ctx, fmt.Sprintf(
+		`from(bucket:"%s")
+			|> range(start:%d) 
+			|> filter(fn: (r) => r._measurement == "%s.%s")
+			|> filter(fn: (r) => (r._field == "open" or r._field == "close" or r._field == "high" or r._field == "low" or r._field == "volume"))
+			|> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+			|> limit(n:%d)`,
+		d.tradeBucket, start.Unix(), productID, timeFrame, limit))
+	if err != nil {
+		return nil, err
+	}
+
+	// When query result is empty but error is not occurred
+	if queryRes == nil {
+		return nil, nil
+	}
+
+	data := []*model.StockAggregate{}
+	for queryRes.Next() {
+		aggregate := &model.StockAggregate{}
+
+		if err := extractFieldValueByKey(queryRes.Record().Values(), "open", &aggregate.Open); err != nil {
+			return nil, fmt.Errorf(`extracting field: can't extract "open": %w`, err)
+		}
+		if err := extractFieldValueByKey(queryRes.Record().Values(), "close", &aggregate.Close); err != nil {
+			return nil, fmt.Errorf(`extracting field: can't extract "close": %v\n`, err)
+		}
+		if err := extractFieldValueByKey(queryRes.Record().Values(), "high", &aggregate.High); err != nil {
+			return nil, fmt.Errorf(`extracting field: can't extract "high": %v\n`, err)
+		}
+		if err := extractFieldValueByKey(queryRes.Record().Values(), "low", &aggregate.Low); err != nil {
+			return nil, fmt.Errorf(`extracting field: can't extract "low": %v\n`, err)
+		}
+		if err := extractFieldValueByKey(queryRes.Record().Values(), "volume", &aggregate.Volume); err != nil {
+			return nil, fmt.Errorf(`extracting field: can't extract "volume": %v\n`, err)
+		}
+		if err := extractFieldValueByKey(queryRes.Record().Values(), "_time", &aggregate.Time); err != nil {
+			return nil, fmt.Errorf(`extracting field: can't extract "_time": %v\n`, err)
+		}
+
+		data = append(data, aggregate)
+	}
+
+	return data, nil
+
+}
+
 func extractFieldValueByKey(values map[string]interface{}, key string, target any) error {
 
 	targetValue := reflect.ValueOf(target)


### PR DESCRIPTION
# 수정 배경

Cursor를 구현하는 과정에서 시간을 기준으로 범위를 선택하면 제한된 거래 시간 때문에 문제가 발생한다는 사실을 알게 되었습니다. 이런 경우에 Cursor는 쿼리의 결과가 비어있을 때 더 이상 가져올 데이터가 없다고 판단할 수밖에 없습니다. 그런데 이 시점이 가장 최근에 생성된 데이터를 가져온 경우일 수도 있지만, 그 날의 거래가 종료된 경우일 수도 있습니다. 

# 수정 내용

특정 시각 이후 생성된 특정 개수의 데이터를 가져오는 쿼리를 구현했습니다.